### PR TITLE
Including libraries(jQuery, Backbone, Underscore) to app 

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -128,32 +128,37 @@ smacssGenerator.prototype.askAppType = function askAppType() {
 };
 
 // Prompt - Ask for the required plugins
-smacssGenerator.prototype.askAppFeatures = function askAppFeatures() {
-    if(this.appType === 'typeFullPackWebApp' || this.appType === 'typeAngularApp' || this.appType === 'typeAdminWebApp') {
+smacssGenerator.prototype.askAppLibraries = function askAppLibraries() {
+    if(this.appType === 'typeFullPackWebApp' || this.appType === 'typeAdminWebApp') {
         var done = this.async();
         var prompts = [{
-            name: 'appFeatures',
-            message: 'How about some additional features',
+            name: 'appLibraries',
+            message: 'Select some libraries to include in your app/site',
             type: 'checkbox',
             choices:[{
                 name: ' jQuery',
                 value: 'includeQuery',
                 checked: true
             },{
-                name: ' Modernizr',
-                value: 'includeModernizr',
+                name: ' Backbone',
+                value: 'includeBackbone',
+                checked: false
+            },{
+                name: ' Underscore',
+                value: 'includeUnderscore',
                 checked: false
             }]
         }];
         this.prompt(prompts, function (answers) {
-            var appFeatures = answers.appFeatures;
+            var appLibraries = answers.appLibraries;
 
             var hasFeature = function (feat) {
-                return appFeatures.indexOf(feat) !== -1;
+                return appLibraries.indexOf(feat) !== -1;
             };
 
             this.includeQuery = hasFeature('includeQuery');
-            this.includeModernizr = hasFeature('includeModernizr');
+            this.includeBackbone = hasFeature('includeBackbone');
+            this.includeUnderscore = hasFeature('includeUnderscore');
 
             done();
         }.bind(this));

--- a/app/index.js
+++ b/app/index.js
@@ -129,7 +129,8 @@ smacssGenerator.prototype.askAppType = function askAppType() {
 
 // Prompt - Ask for the required plugins
 smacssGenerator.prototype.askAppLibraries = function askAppLibraries() {
-    if(this.appType === 'typeFullPackWebApp' || this.appType === 'typeAdminWebApp') {
+    if(this.appType === 'typeFullPackWebApp' ||
+       this.appType === 'typeAdminWebApp') {
         var done = this.async();
         var prompts = [{
             name: 'appLibraries',

--- a/app/templates/_typeAdminWebApp/_bower.json
+++ b/app/templates/_typeAdminWebApp/_bower.json
@@ -4,8 +4,9 @@
   "dependencies": {
     "bootstrap": "*",
     <% if (includeQuery) { %>
-    "jquery": "*"<% } if (includeModernizr) { %>,
-    "modernizr": "*" <% } %>
+    "jquery": "*"<% } if (includeBackbone) { %>,
+    "backbone": "*"<% } if (includeUnderscore) { %>,
+    "underscore": "*" <% } %>
   },
   "devDependencies": {
 

--- a/app/templates/_typeAngularApp/_bower.json
+++ b/app/templates/_typeAngularApp/_bower.json
@@ -6,9 +6,7 @@
     "angular-resource": "1.2.6"<% } if (includeSanitizeModule) { %>,
     "angular-sanitize": "1.2.6"<% } if (includeRouteModule) { %>,
     "angular-route": "1.2.6"<%    } if (includeAnimateModule) { %>,
-    "angular-animate": "1.2.6"<%  } if (includeQuery) { %>,
-    "jquery": "*"<%               } if (includeModernizr) { %>,
-    "modernizr": "*" <% } %>
+    "angular-animate": "1.2.6" <% } %>
   },
   "devDependencies": {
 

--- a/app/templates/_typeFullPackWebApp/_bower.json
+++ b/app/templates/_typeFullPackWebApp/_bower.json
@@ -3,8 +3,9 @@
   "version": "0.0.1",
   "dependencies": {
     <% if (includeQuery) { %>
-    "jquery": "*"<% } if (includeModernizr) { %>,
-    "modernizr": "*" <% } %>
+    "jquery": "*"<% } if (includeBackbone) { %>,
+    "backbone": "*"<% } if (includeUnderscore) { %>,
+    "underscore": "*" <% } %>
   },
   "devDependencies": {
 

--- a/test/test.js
+++ b/test/test.js
@@ -39,7 +39,7 @@ describe('Generator Smacss test', function () {
 
     helpers.mockPrompt(this.smacss, {
       appType: ['typeFullPackWebApp'],
-      appFeatures: ['includeQuery']
+      appLibraries: ['includeQuery']
     });
 
     this.smacss.run(function () {


### PR DESCRIPTION
**Why?**
- The user should be able to include commonly used libraries(eg. jQuery) while creating the app

**What's Done?**
- Included most commonly used libraries(jQuery, Backbone, Underscore) as options
- Excluded modernizer and it's not widely used. Also, for the reason now modenizer doesn't ship as a single file which causes an issue (https://github.com/FuelFrontend/generator-smacss/issues/60)